### PR TITLE
Fixed running multiple tests on one server not working

### DIFF
--- a/spec/services/ng-independenceSpec.js
+++ b/spec/services/ng-independenceSpec.js
@@ -23,6 +23,8 @@ describe('ng-independence',function() {
         angular.mock.inject(["$independence", function(_$independence_) {
             $independence = _$independence_;
         }]);
+
+        localStorage.clear()
     });
 
     describe('act', function() {


### PR DESCRIPTION
Before this change $independence would leave all it's queue in the local storage and they would carry between different test sessions, resulting in failed tests in ng-independenceSpec.js from the second test session onward.