### PR TITLE
Fixed $message not listing to WebSocket before at least one message is sent

### DIFF
--- a/src/js/services/ng-message.js
+++ b/src/js/services/ng-message.js
@@ -75,6 +75,7 @@ define('services/ng-message',[
                     });
                 },
                 on: function(topic, handler) {
+                    init();
                     listeners.push({ topic: topic, handler: handler });
                 }
             };


### PR DESCRIPTION
Basically, only $message.send runs init; And so before this change listening to messages only worked after you sent at least one. Now on also initialises the WebSocket, so listening to messages works without sending a message first. This resulted in the ranking not being updated correctly in a fresh tab- because 
a fresh tab you only opened rankings in didn't send any messages, it didn't initialise the WebSocket and so doesn't respond to 'scores:reload' messages.