### PR TITLE
made ng-message re-open the websocket after it is closed and fixed sending messages too quickly

### DIFF
--- a/src/js/services/ng-message.js
+++ b/src/js/services/ng-message.js
@@ -14,12 +14,14 @@ define('services/ng-message',[
             var isInitializedPromise;
             var listeners = [];
             var token = parseInt(Math.floor(0x100000*(Math.random())), 16);
+            var socketOpen;
 
             function init() {
-                if (isInitializedPromise) {
+                if (isInitializedPromise && socketOpen) {
                     return isInitializedPromise;
                 }
                 var def = $q.defer();
+                socketOpen = true;
                 isInitializedPromise = def.promise;
                 return $settings.init().then(function(settings) {
                     if (!(settings.mhub && settings.node)) {
@@ -39,6 +41,7 @@ define('services/ng-message',[
                         log("socket error", e);
                     };
                     ws.onclose = function() {
+                        socketOpen = false;
                         log("socket close");
                     };
                     ws.onmessage = function(msg) {

--- a/src/js/services/ng-message.js
+++ b/src/js/services/ng-message.js
@@ -62,6 +62,7 @@ define('services/ng-message',[
 
 
             return {
+                init: init,
                 send: function(topic,data) {
                     return init().then(function(ws) {
                         data = data || {};

--- a/src/js/services/ng-message.js
+++ b/src/js/services/ng-message.js
@@ -11,16 +11,16 @@ define('services/ng-message',[
     return module.service('$message',[
         '$http','$settings','$q',
         function($http,$settings,$q) {
-            var promise;
+            var isInitializedPromise;
             var listeners = [];
             var token = parseInt(Math.floor(0x100000*(Math.random())), 16);
 
             function init() {
-                if (promise) {
-                    return promise;
+                if (isInitializedPromise) {
+                    return isInitializedPromise;
                 }
                 var def = $q.defer();
-                promise = def.promise;
+                isInitializedPromise = def.promise;
                 return $settings.init().then(function(settings) {
                     if (!(settings.mhub && settings.node)) {
                         throw new Error('no message bus configured');
@@ -58,7 +58,7 @@ define('services/ng-message',[
                             listener.handler(data, msg);
                         });
                     };
-                    return promise;
+                    return isInitializedPromise;
                 });
             }
 


### PR DESCRIPTION
Before, once a web socket closed (for example, your connection dropped) it would never re-open, and all consequent messages would result in an error. This PR changed this behaviour such that when the websocket closes, calls to send would reinitialise it.
This PR also fixes the discarded messages problem that happens if you call send too quickly using imported commits from auto-publish (included this for easier merges down the line, and because this is also a needed fix which shouldn't be a part  of that PR exclusively and fits here)