### PR TITLE
Fixed scores view not updating correctly when offline

### DIFF
--- a/src/js/views/scores.js
+++ b/src/js/views/scores.js
@@ -27,7 +27,7 @@ define('views/scores', [
                 return $scores.scores;
             }, function () {
                 $scope.scores = enrich($scores.scores);
-            });
+            }, true);
 
             $scores.init().then(function() {
                 $scope.stages = $stages.stages;


### PR DESCRIPTION
Caused by how when offline, the scores array is updated in-place, however the watcher doesn't use object equality.