### PR TITLE
Fixed the "thank you" message blocking ng-scores

### DIFF
--- a/spec/views/scoresheetSpec.js
+++ b/spec/views/scoresheetSpec.js
@@ -488,8 +488,10 @@ describe('scoresheet',function() {
                         published: false,
                         calcFilename: fileName
                     });
-                expect($window.alert).toHaveBeenCalledWith('Thanks for submitting a score of 0 points for team (123) foo in Voorrondes 1.');
-                done();
+                setTimeout(() => {
+                    expect($window.alert).toHaveBeenCalledWith('Thanks for submitting a score of 0 points for team (123) foo in Voorrondes 1.')
+                    done();
+                }, 0);
             });
         });
 
@@ -525,10 +527,11 @@ describe('scoresheet',function() {
                         calcFilename: fileName,
                         published: true
                     });
-
-                expect($window.alert).toHaveBeenCalledWith(`Thanks for submitting a score of 0 points for team (${dummyTeam.number})` +
-                         ` ${dummyTeam.name} in ${dummyStage.name} 1.`);
-                done();
+                setTimeout(() => {
+                    expect($window.alert).toHaveBeenCalledWith(`Thanks for submitting a score of 0 points for team (${dummyTeam.number})` +
+                        ` ${dummyTeam.name} in ${dummyStage.name} 1.`);
+                    done();
+                }, 0);
             });
         });
 

--- a/src/js/views/scoresheet.js
+++ b/src/js/views/scoresheet.js
@@ -267,7 +267,7 @@ define('views/scoresheet',[
                     message = `Thanks for submitting a score of ${scoreEntry.score} points for team (${scoresheet.team.number})` +
                         ` ${scoresheet.team.name} in ${scoresheet.stage.name} ${scoresheet.round}.`;
                     $scope.clear();
-                    $window.alert(message);
+                    setTimeout(() => $window.alert(message), 0);
                 }).catch(function(err) {
                     log(`Error: ${err}`);
                     message = `Thanks for submitting a score of ${scoreEntry.score} points for team` +


### PR DESCRIPTION
Basically, classic JS shenanigans. Javascript being a one-thread language, promises don't actually execute asynchronously; So different `then()` callbacks don't execute independently when the promise resolves. Since alert blocks the current thread, this means that when the score is created (submitted) the then in the scoresheet view executes and alerts the user with the "thank you" message. This means that the then in ng-scores which calls accept scores to do things like auto-broadcasting and updating the local scores object is blocked by the "thank you" alert. To solve this, I forked the call to alert in scoresheet's then using `setTimeout()`, to make the JS thread execute the alert as soon as it is idle, instead of immediately, which avoids blocking.