### PR TITLE
fix modified properties of moved stage being reverted.

### DIFF
--- a/src/js/services/ng-stages.js
+++ b/src/js/services/ng-stages.js
@@ -125,6 +125,9 @@ define('services/ng-stages',[
         Stages.prototype.moveStage = function(stage,steps) {
             var oldIndex = stage.index;
             var rawStage = this._rawStages[oldIndex];
+            Object.keys(rawStage).forEach((key)=>{
+                rawStage[key] = stage[key];
+            });
             //remove from the list
             this._rawStages.splice(oldIndex,1);
             //calculate insert position

--- a/src/js/services/ng-stages.js
+++ b/src/js/services/ng-stages.js
@@ -125,6 +125,17 @@ define('services/ng-stages',[
         Stages.prototype.moveStage = function(stage,steps) {
             var oldIndex = stage.index;
             var rawStage = this._rawStages[oldIndex];
+            // changes made in the stages (name or round number) were only changing
+            // $scope.stages and so when moveStage is called, those changes are lost. 
+            // to fix this, we iterate over the properties of the stage we are about to move
+            // and for each one, we set it to equal the matching value from the stage passed
+            // as a parameter. 
+            //
+            // the `stage` parameter contains any changes made to the stage (in the browser) before 
+            // being saved to a file.
+
+            // this essentially updates the rawStage object.
+        
             Object.keys(rawStage).forEach((key)=>{
                 rawStage[key] = stage[key];
             });


### PR DESCRIPTION
this fixed #72 

the problem was the mismatch between `_rawStages` and the `$scope.stages` array. 

changes made in the stages (name or round number) were only changing `$scope.stages` and so when `moveStage` is called in the `ng-stages` service, those changes are lost.