### PR TITLE
Fixed building export files exporting the scores array and not the actual score values

### DIFF
--- a/spec/views/rankingSpec.js
+++ b/spec/views/rankingSpec.js
@@ -146,8 +146,8 @@ describe('ranking', function() {
 
             $scope.scoreboard = {
                 'qualifying': [
-                    { rank: 1, team: { name: "foo", number: 123 }, highest: { score: 10 }, scores: [0, 10, 5] },
-                    { rank: 1, team: { name: "\"bar\"", number: 456 }, highest: { score: 10 }, scores: [10, 0, 5] }
+                    {rank: 1, team: {name: "foo", number: 123}, highest: {score: 10}, scores: [{score: 0}, {score: 10}, {score: 5}]},
+                    {rank: 1, team: {name: "\"bar\"", number: 456}, highest: {score: 10}, scores: [{score: 10}, {score: 0}, {score: 5}]}
                 ]
             };
             $scope.buildExportFiles();
@@ -159,8 +159,8 @@ describe('ranking', function() {
         it('should not skip empty values, but include as empty string',function() {
             $scope.scoreboard = {
                 'qualifying': [
-                    { team: { name: "foo", number: 123 }, highest: { score: 10 }, scores: [0, 10, 5] },
-                    { team: { name: "\"bar\"", number: 456 }, highest: { score: 10 }, scores: [10, 0, 5] }
+                    {team: {name: "foo", number: 123}, highest: {score: 10}, scores: [{score: 0}, {score: 10}, {score: 5}]},
+                    {team: {name: "\"bar\"", number: 456}, highest: {score: 10}, scores: [{score: 10}, {score: 0}, {score: 5}]}
                 ]
             };
             $scope.$digest();

--- a/src/js/views/ranking.js
+++ b/src/js/views/ranking.js
@@ -104,7 +104,7 @@ define('views/ranking',[
                 array.forEach(function (row) {
                     row = row.map((elem) => elem || elem === 0 ? String(elem) : "");
                     string = string.concat(settings.lineStartString ? String(settings.lineStartString) : "");
-                    string = string.concat(row.join(settings.separatorString ? String(settings.separatorString) : ""));
+                    string = string.concat(row.join(settings.separatorString ? String(settings.separatorString) : ","));
                     string = string.concat((settings.lineEndString ? String(settings.lineEndString) : "") + "\r\n");
                 });
                 return string;

--- a/src/js/views/ranking.js
+++ b/src/js/views/ranking.js
@@ -121,7 +121,7 @@ define('views/ranking',[
                     var teams = $scope.scoreboard[stageID];
                     teams = teams.map(function (teamEntry) {
                         return [teamEntry.rank, teamEntry.team.number,
-                            teamEntry.team.name, teamEntry.highest.score].concat(teamEntry.scores);
+                            teamEntry.team.name, teamEntry.highest.score].concat(teamEntry.scores.map(scoreObject => scoreObject ? scoreObject.score : "no score"));//if a team hasn't played in a round, it will show the score in that round as "no score"
                     });
                     $scope.exportFiles[stageID] = "data:text/csv;charset=utf-8,"+encodeURIComponent($scope.encodeArray(teams));
                 });

--- a/src/js/views/ranking.js
+++ b/src/js/views/ranking.js
@@ -121,7 +121,7 @@ define('views/ranking',[
                     var teams = $scope.scoreboard[stageID];
                     teams = teams.map(function (teamEntry) {
                         return [teamEntry.rank, teamEntry.team.number,
-                            teamEntry.team.name, teamEntry.highest.score].concat(teamEntry.scores.map(scoreObject => scoreObject ? scoreObject.score : "no score"));//if a team hasn't played in a round, it will show the score in that round as "no score"
+                            teamEntry.team.name, teamEntry.highest.score].concat(teamEntry.scores.map(scoreObject => scoreObject ? scoreObject.score : 0));//if a team hasn't played in a round, it will export the score in that round as 0
                     });
                     $scope.exportFiles[stageID] = "data:text/csv;charset=utf-8,"+encodeURIComponent($scope.encodeArray(teams));
                 });


### PR DESCRIPTION
Since now the scoreboard contains an array of the score object instead of values, with undefined as a place holder if a team doesn't have an entry for a specific round, a fix was required. A side effect of this fix is that now if a team didn't play in a round it now writes "no score" in the appropriate place; This made more sense to me than not including any indication. 

Note that I also changed the default separator character to a `,` instead of an empty string. This means you can't build export files with an empty string as a separator, which means if the user for example deletes the separator string in the settings tab it would not start exporting nonsensical csv files. This also fixes the fact that $settings doesn't define a default separator character when generating the default settings, but I didn't want to change ng-settings.js unnecessarily.