### PR TITLE
Fixed lock files not unlocking if action fails

### DIFF
--- a/server_modules/scores.js
+++ b/server_modules/scores.js
@@ -20,7 +20,7 @@ function reduceToMap(key) {
 function changeScores(action) {
     return new Promise(function(res, rej) {
         var path = fileSystem.getDataFilePath('scores.json');
-        lockfile.lock('scores.json.lock', { retries: 5, retryWait: 100 }, function (err) {
+        lockfile.lock('scores.json.lock', { retries: 5, retryWait: 100 , stale : 1000}, function (err) {
             if(err) rej(err);
             fileSystem.readJsonFile(path)
             .catch(function(err) {


### PR DESCRIPTION
Before this change, if an action given to changeScores failed, changeScores wouldn't unlock the lock file; this was because it unlocked the lock only after trying to write the new scores file (it would try to write, and whether is succeeded in writing the scores to disk or failed, it unlocked the lock). This was problematic because the action supplied to changeScores can reject all on it's own, and in such case it would never gotten as far as trying to write the scores to disk, and wouldn't unlocked the lock after trying. This was solved by moving the unlocking component to the end of the whole promise chain, so if action rejects it will still call the unlock.

I also made all locks older than 1 second stale, which means they're automatically discarded, and added what seemed to be a missing unlock in line 30 (though it might be that a call to throw in that context result in that promise rejecting, in which case that's an unneeded unlock).