### PR TITLE
fixed invalid requests staying in independence queue

### DIFF
--- a/src/js/services/ng-independence.js
+++ b/src/js/services/ng-independence.js
@@ -3,8 +3,9 @@
  * use them later when the server's back up.
  */
 define('services/ng-independence',[
-    'services/ng-services'
-],function(module) {
+    'services/ng-services',
+    'services/log'
+],function(module, log) {
     "use strict";
 
     return module.service('$independence', ['$q','$localStorage', '$http',
@@ -44,6 +45,7 @@ define('services/ng-independence',[
             promise.then(() => delete $localStorage[action.originalKey]);
             promise.catch(error => {
                 if (error.status === 500){
+                    log(`server reports error in request to ${action.url} with data ${JSON.stringify(action.data)}`);
                     delete $localStorage[action.originalKey];
                 }
             });

--- a/src/js/services/ng-independence.js
+++ b/src/js/services/ng-independence.js
@@ -42,6 +42,11 @@ define('services/ng-independence',[
         function actionToPromise(action) {
             const promise = $http.post(action.url, action.data);
             promise.then(() => delete $localStorage[action.originalKey]);
+            promise.catch(error => {
+                if (error.status === 500){
+                    delete $localStorage[action.originalKey];
+                }
+            });
             return promise;
         }
 


### PR DESCRIPTION
Before this change, request that are invalid- i.e. result in a server error would stay in the independence queue indefinitely (for example, if you request to delete a score that was already deleted by another user while you were offline). This is problematic because they would clog up the queue, resulting in a lot of unnecessary traffic and also unnecessary server actions that can, for example, lock the scores file and delay other requests. 