### PR TITLE
Fixed input for header in team import dialog

### DIFF
--- a/src/views/dialogs.html
+++ b/src/views/dialogs.html
@@ -18,7 +18,7 @@
 
             <h4>Data format</h4>
             <div>
-                <input type="checkbox" ng-model="importHeader"> Data contains header </input>
+                <input type="number" ng-model="headerLength"> Header Length (Amount of line to skip)</input>
             </div>
             <table>
                 <tr>

--- a/src/views/dialogs.html
+++ b/src/views/dialogs.html
@@ -18,7 +18,7 @@
 
             <h4>Data format</h4>
             <div>
-                <input type="number" ng-model="headerLength"> Header Length (Amount of line to skip)</input>
+                <input type="number" ng-model="headerLength"> Header Length (Number of lines to skip)</input>
             </div>
             <table>
                 <tr>

--- a/src/views/dialogs.html
+++ b/src/views/dialogs.html
@@ -52,7 +52,7 @@
             <hr style="margin-top: 7px; margin-bottom: 0;">
 
             <h4>Data to be loaded:</h4>
-            <table>
+            <table class="table">
                 <span ng-hide="importLines">
                     No data available.
                 </span>


### PR DESCRIPTION
It didn't point to the correct `ng-model`, and had the wrong text and type; What I had in my "import teams from csv" PR probably just got overruled in some merge.

I also made the team preview readable by adding a horizontal divider between entries, another change that was in my "import from csv" pr that probably got accidentally overridden in some merge.