### PR TITLE
Removed the interface to change mhub settings

### DIFF
--- a/src/views/pages/settings.html
+++ b/src/views/pages/settings.html
@@ -20,7 +20,7 @@
         <li role="presentation" ng-class="{active:tab===1}"><a href ng-click="tab = 1">Tables &amp; Referees</a></li>
         <li role="presentation" ng-class="{active:tab===2}"><a href ng-click="tab = 2">Rounds &amp; Stages</a></li>
         <li role="presentation" ng-class="{active:tab===3}"><a href ng-click="tab = 3">Challenge</a></li>
-        <li role="presentation" ng-class="{active:tab===4}"><a href ng-click="tab = 4">Messaging</a></li>
+        <!--<li role="presentation" ng-class="{active:tab===4}"><a href ng-click="tab = 4">Messaging</a></li>-->
         <li role="presentation" ng-class="{active:tab===5}"><a href ng-click="tab = 5">Automation</a></li>
         <li role="presentation" ng-class="{active:tab===6}"><a href ng-click="tab = 6">Log</a></li>
     </ul>


### PR DESCRIPTION
This prevents the user from accidentally changing the settings for mhub- the address of the mhub server as well as the node; This retains the ability to easily re-enable the ability to change those settings for development by just un-commenting the link to the "Messaging" tab.