### PR TITLE
Added explanation and polish to the Current Stage setting

### DIFF
--- a/src/views/pages/settings.html
+++ b/src/views/pages/settings.html
@@ -143,10 +143,17 @@
                 </p>
             </div>
         </div>
-        <p>
-            <select title="currentStageSelect" ng-model="settings.currentStage" ng-options="stage.id as stage.name for stage in allStages | filter : {rounds :'!0'}">
-            </select>
-        </p>
+        <div class="card">
+            <h3 class="card-header">Current Stage</h3>
+            <div class="card-actions">
+                <label for="currentStageSelect">
+                    <select id="currentStageSelect" ng-model="settings.currentStage" ng-options="stage.id as stage.name for stage in allStages | filter : {rounds :'!0'}">
+                    </select>
+                    <br/>
+                    This setting is used for automatic broadcasting and to auto-fill the stage in the ref's scoresheets
+                </label>
+            </div>
+        </div>
     </div>
     <div ng-show="tab === 3">
         <p>


### PR DESCRIPTION
Gave it its own card with an appropriate header and a label to explain what this setting does.

Notice this setting is the same as the the auto-broadcast setting in the Automation tab- both point to the `settings.currentStage` ng-model.