### PR TITLE
Mhub settings are now default per-user unless specified otherwise

### DIFF
--- a/src/js/services/ng-message.js
+++ b/src/js/services/ng-message.js
@@ -24,16 +24,26 @@ define('services/ng-message',[
                 socketOpen = true;
                 isInitializedPromise = def.promise;
                 return $session.load().then(() => $settings.init()).then(function(settings) {
-                    if (!(settings.mhub && settings.node)) {
-                        throw new Error('no message bus configured');
+                    var mhubNode;
+                    var mhubAddress;
+                    if(settings.customMhub && settings.mhub){
+                        mhubAddress = settings.mhub;
+                    } else {
+                        mhubAddress = `ws://${window.location.hostname}:13900`;
                     }
 
-                    var ws = new WebSocket(settings.mhub);
-                    ws.node = settings.node;
+                    if(settings.customMhub && settings.node){
+                        mhubNode = settings.node;
+                    } else {
+                        mhubNode = 'default';
+                    }
+
+                    var ws = new WebSocket(mhubAddress);
+                    ws.node = mhubNode;
                     ws.onopen = function() {
                         ws.send(JSON.stringify({
                             type: "subscribe",
-                            node: settings.node
+                            node: mhubNode
                         }));
 
                         let passport = $session.get('passport');
@@ -41,7 +51,7 @@ define('services/ng-message',[
                         if(passport) {
                             ws.send(JSON.stringify({
                                 type: "login",
-                                node: settings.node,
+                                node: mhubNode,
                                 username: passport.user.username,
                                 password: passport.user.mhubPassword
                             }));
@@ -90,7 +100,7 @@ define('services/ng-message',[
                 },
                 on: function(topic, handler, ignoreSelfMessages) {
                     init();
-                    listeners.push({ topic: topic, handler: (msgData, msg) => msg.fromMe && ignoreSelfMessages ? void(0) : handler(msgData, msg)});
+                    listeners.push({ topic: topic, handler: (msgData, msg) => msg.fromMe && ignoreSelfMssages ? void(0) : handler(msgData, msg)});
                 }
             };
         }

--- a/src/views/pages/settings.html
+++ b/src/views/pages/settings.html
@@ -174,10 +174,10 @@
     <div ng-show="tab === 4">
         <p>
             <span class="textfield">
-                <input type="checkbox" ng-model="settings.mhubEnabled"/>
-                <label for="">Enable messaging</label>
+                <input type="checkbox" ng-model="settings.customMhub"/>
+                <label for="">Custom messaging options</label>
             </span>
-            Enable publishing of scores and rankings, live updates to the score keeping lists, etc.
+            Enable custom settings for mhub. If you don't know what this means, keep this setting turned <b>off</b>.
         </p>
         <p>
             <span class="textfield">


### PR DESCRIPTION
This was done by replacing the unused "enable messaging" setting with the new "custom mhub settings" seen here- 
![screenshot from 2017-12-01 15-55-03](https://user-images.githubusercontent.com/8599334/33485702-0c9e04a4-d6b0-11e7-9dba-f1ce4ddaf300.png)

Unless this setting is ticked, your mhub-address will always be derived from the host name used to connect to the site, and your mhub node will always be "default".