### PR TITLE
Fixing a problem that the objectives are not sorted by their index

### DIFF
--- a/tools/buildchallenge.js
+++ b/tools/buildchallenge.js
@@ -75,12 +75,19 @@ function parseMission(xml,index) {
     //only return elements starting with 'objective-''
     var objectives = Object.keys(xml).filter(function(key) {
         return (key.indexOf('objective-') === 0);
-    }).reduce(function(all,key) {
+    }).reduce(function(all,key){
         return all.concat(xml[key].map(function(objective) {
             objective.$.type = key.replace('objective-','');
             return objective;
         }));
-    },[]);
+    },[]).sort(function (a, b) {
+        //Sorting the array by the objective id
+        let aIndx = a.$.id.search("-[0-9]");
+        let aNum = parseInt(a.$.id[aIndx+1]);
+        let bIndx = b.$.id.search("-[0-9]");
+        let  bNum = parseInt(b.$.id[bIndx+1]);
+        return aNum > bNum;
+    });
     return {
         title: getString(xml.$.name),
         description: getString(xml.$.description),
@@ -127,7 +134,6 @@ function processFile(fn) {
     // console.log(strings);
     // return;
         var missions = def['fll:challenge'].mission;
-        // console.log(missions);
         var jsm = {
             title: def['fll:challenge'].$.name,
             missions: missions.map(parseMission),


### PR DESCRIPTION
The problem was that the xml parser puts the objectives in array by there tag.
Aka if there are some "objective-yesno" and some "objective-enum" they will be put in different arrays in the object returned by the parser.
I added a sort after the reduce method to sort the objectives by their id - that fixed the problem.